### PR TITLE
update debug module to ~1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "test": "mocha --reporter dot"
   },
   "dependencies": {
-    "crc32-stream": "~0.2.0",
-    "deflate-crc32-stream": "~0.1.0",
-    "readable-stream": "~1.0.26",
-    "lodash.defaults": "~2.4.1",
     "buffer-crc32": "~0.2.1",
-    "debug": "~0.8.0"
+    "crc32-stream": "~0.2.0",
+    "debug": "~1.0.2",
+    "deflate-crc32-stream": "~0.1.0",
+    "lodash.defaults": "~2.4.1",
+    "readable-stream": "~1.0.26"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
I know this seems like a trivial pull request but I'm working on packaging up [Groove Basin](https://github.com/andrewrk/groovebasin/) for Debian, which indirectly depends on the `debug` module twice, with conflicting versions. NPM handles these version conflicts by simultaneously depending on multiple versions, while Debian requires that there be only one version of everything for security reasons. Fortunately, the solution is simple - if `node-zip-stream` updates to the latest version of `debug` then everybody is happy.

I have verified that the tests still pass. I would be grateful if you merged this and published a new version.
