### PR TITLE
actually use STORE method if level is 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ var ZipStream = module.exports = function(options) {
     delete options.level;
   }
 
-  if (options.zlib.level && options.zlib.level === 0) {
+  if (typeof options.zlib.level === 'number' && options.zlib.level === 0) {
     options.store = true;
   }
 

--- a/test/pack.js
+++ b/test/pack.js
@@ -139,6 +139,7 @@ describe('pack', function() {
       var testStream = new WriteHashStream('tmp/store-level0.zip');
 
       testStream.on('close', function() {
+        assert.equal(testStream.digest, '70b50994c971dbb0e457781cf6d23ca82e5ccbc0');
         done();
       });
 


### PR DESCRIPTION
0 is falsy, so Deflate was used for level 0. Verified that the digest in the test assertion reflects a STORE archive using 7zip.

Thanks!