### PR TITLE
remove unused lodash dependence

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "archiver-utils": "^1.3.0",
     "compress-commons": "^1.2.0",
-    "lodash": "^4.8.0",
     "readable-stream": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR removes the `lodash` dependence, which, as far as i can tell, is stated as a dependence but never used. Removing `lodash` can help with pulling in the quite large `lodash` baggage (4.8MB)

Fixes #32