### PR TITLE
blank files should be stored

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ inherits(ZipStream, ZipArchiveOutputStream);
  * @param  {Object} data
  * @return {Object}
  */
-ZipStream.prototype._normalizeFileData = function(data) {
+ZipStream.prototype._normalizeFileData = function(source, data) {
   data = util.defaults(data, {
     type: 'file',
     name: null,
@@ -81,7 +81,7 @@ ZipStream.prototype._normalizeFileData = function(data) {
     }
   }
 
-  if (isDir || isSymlink) {
+  if (isDir || isSymlink || source.length === 0) {
     data.store = true;
   }
 
@@ -110,7 +110,7 @@ ZipStream.prototype.entry = function(source, data, callback) {
     callback = this._emitErrorCallback.bind(this);
   }
 
-  data = this._normalizeFileData(data);
+  data = this._normalizeFileData(source, data);
 
   if (data.type !== 'file' && data.type !== 'directory' && data.type !== 'symlink') {
     callback(new Error(data.type + ' entries not currently supported'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zip-stream",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
If the empty file is not stored, using ZipInputStream to decompress will throw the following error：

```
    java.util.zip.ZipException: only DEFLATED entries can have EXT descriptor
    at java.util.zip.ZipInputStream.readLOC(ZipInputStream.java:310)
    at java.util.zip.ZipInputStream.getNextEntry(ZipInputStream.java:122)
    at Alan.streamToUnzipFile(Alan.java:59)
    at Alan.main(Alan.java:29)
```