### PR TITLE
Refactor code to use ES6 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,11 @@
  * @license [MIT]{@link https://github.com/archiverjs/node-zip-stream/blob/master/LICENSE}
  * @copyright (c) 2014 Chris Talkington, contributors.
  */
-var inherits = require('util').inherits;
+const inherits = require('util').inherits;
 
-var ZipArchiveOutputStream = require('compress-commons').ZipArchiveOutputStream;
-var ZipArchiveEntry = require('compress-commons').ZipArchiveEntry;
+const { ZipArchiveOutputStream, ZipArchiveEntry } = require('compress-commons');
 
-var util = require('archiver-utils');
+const util = require('archiver-utils');
 
 /**
  * @constructor
@@ -23,7 +22,7 @@ var util = require('archiver-utils');
  * @param {Object} [options.zlib] Passed to [zlib]{@link https://nodejs.org/api/zlib.html#zlib_class_options}
  * to control compression.
  */
-var ZipStream = module.exports = function(options) {
+const ZipStream = module.exports = function(options) {
   if (!(this instanceof ZipStream)) {
     return new ZipStream(options);
   }
@@ -67,8 +66,8 @@ ZipStream.prototype._normalizeFileData = function(data) {
     comment: ''
   });
 
-  var isDir = data.type === 'directory';
-  var isSymlink = data.type === 'symlink';
+  let isDir = data.type === 'directory';
+  const isSymlink = data.type === 'symlink';
 
   if (data.name) {
     data.name = util.sanitizePath(data.name);
@@ -127,7 +126,7 @@ ZipStream.prototype.entry = function(source, data, callback) {
     return;
   }
 
-  var entry = new ZipArchiveEntry(data.name);
+  const entry = new ZipArchiveEntry(data.name);
   entry.setTime(data.date, this.options.forceLocalTime);
 
   if (data.store) {

--- a/index.js
+++ b/index.js
@@ -5,165 +5,159 @@
  * @license [MIT]{@link https://github.com/archiverjs/node-zip-stream/blob/master/LICENSE}
  * @copyright (c) 2014 Chris Talkington, contributors.
  */
-const inherits = require('util').inherits;
 
 const { ZipArchiveOutputStream, ZipArchiveEntry } = require('compress-commons');
 
 const util = require('archiver-utils');
 
-/**
- * @constructor
- * @extends external:ZipArchiveOutputStream
- * @param {Object} [options]
- * @param {String} [options.comment] Sets the zip archive comment.
- * @param {Boolean} [options.forceLocalTime=false] Forces the archive to contain local file times instead of UTC.
- * @param {Boolean} [options.forceZip64=false] Forces the archive to contain ZIP64 headers.
- * @param {Boolean} [options.store=false] Sets the compression method to STORE.
- * @param {Object} [options.zlib] Passed to [zlib]{@link https://nodejs.org/api/zlib.html#zlib_class_options}
- * to control compression.
- */
-const ZipStream = module.exports = function(options) {
-  if (!(this instanceof ZipStream)) {
-    return new ZipStream(options);
-  }
+module.exports = class ZipStream extends ZipArchiveOutputStream {
+  /**
+   * @constructor
+   * @extends external:ZipArchiveOutputStream
+   * @param {Object} [options]
+   * @param {String} [options.comment] Sets the zip archive comment.
+   * @param {Boolean} [options.forceLocalTime=false] Forces the archive to contain local file times instead of UTC.
+   * @param {Boolean} [options.forceZip64=false] Forces the archive to contain ZIP64 headers.
+   * @param {Boolean} [options.store=false] Sets the compression method to STORE.
+   * @param {Object} [options.zlib] Passed to [zlib]{@link https://nodejs.org/api/zlib.html#zlib_class_options}
+   * to control compression.
+   */
+  constructor(options) {
+    options = options || {};
+    options.zlib = options.zlib || {};
+    super(options);
 
-  options = this.options = options || {};
-  options.zlib = options.zlib || {};
+    if (typeof options.level === 'number' && options.level >= 0) {
+      options.zlib.level = options.level;
+      delete options.level;
+    }
 
-  ZipArchiveOutputStream.call(this, options);
+    if (!options.forceZip64 && typeof options.zlib.level === 'number' && options.zlib.level === 0) {
+      options.store = true;
+    }
 
-  if (typeof options.level === 'number' && options.level >= 0) {
-    options.zlib.level = options.level;
-    delete options.level;
-  }
-
-  if (!options.forceZip64 && typeof options.zlib.level === 'number' && options.zlib.level === 0) {
-    options.store = true;
-  }
-
-  if (options.comment && options.comment.length > 0) {
-    this.setComment(options.comment);
-  }
-};
-
-inherits(ZipStream, ZipArchiveOutputStream);
-
-/**
- * Normalizes entry data with fallbacks for key properties.
- *
- * @private
- * @param  {Object} data
- * @return {Object}
- */
-ZipStream.prototype._normalizeFileData = function(data) {
-  data = util.defaults(data, {
-    type: 'file',
-    name: null,
-    linkname: null,
-    date: null,
-    mode: null,
-    store: this.options.store,
-    comment: ''
-  });
-
-  let isDir = data.type === 'directory';
-  const isSymlink = data.type === 'symlink';
-
-  if (data.name) {
-    data.name = util.sanitizePath(data.name);
-
-    if (!isSymlink && data.name.slice(-1) === '/') {
-      isDir = true;
-      data.type = 'directory';
-    } else if (isDir) {
-      data.name += '/';
+    if (options.comment && options.comment.length > 0) {
+      this.setComment(options.comment);
     }
   }
 
-  if (isDir || isSymlink) {
-    data.store = true;
-  }
+  /**
+   * Normalizes entry data with fallbacks for key properties.
+   *
+   * @private
+   * @param  {Object} data
+   * @return {Object}
+   */
+  _normalizeFileData(data) {
+    data = util.defaults(data, {
+      type: 'file',
+      name: null,
+      linkname: null,
+      date: null,
+      mode: null,
+      store: this.options.store,
+      comment: '',
+    });
 
-  data.date = util.dateify(data.date);
+    let isDir = data.type === 'directory';
+    const isSymlink = data.type === 'symlink';
 
-  return data;
-};
+    if (data.name) {
+      data.name = util.sanitizePath(data.name);
 
-/**
- * Appends an entry given an input source (text string, buffer, or stream).
- *
- * @param  {(Buffer|Stream|String)} source The input source.
- * @param  {Object} data
- * @param  {String} data.name Sets the entry name including internal path.
- * @param  {String} [data.comment] Sets the entry comment.
- * @param  {(String|Date)} [data.date=NOW()] Sets the entry date.
- * @param  {Number} [data.mode=D:0755/F:0644] Sets the entry permissions.
- * @param  {Boolean} [data.store=options.store] Sets the compression method to STORE.
- * @param  {String} [data.type=file] Sets the entry type. Defaults to `directory`
- * if name ends with trailing slash.
- * @param  {Function} callback
- * @return this
- */
-ZipStream.prototype.entry = function(source, data, callback) {
-  if (typeof callback !== 'function') {
-    callback = this._emitErrorCallback.bind(this);
-  }
-
-  data = this._normalizeFileData(data);
-
-  if (data.type !== 'file' && data.type !== 'directory' && data.type !== 'symlink') {
-    callback(new Error(data.type + ' entries not currently supported'));
-    return;
-  }
-
-  if (typeof data.name !== 'string' || data.name.length === 0) {
-    callback(new Error('entry name must be a non-empty string value'));
-    return;
-  }
-
-  if (data.type === 'symlink' && typeof data.linkname !== 'string') {
-    callback(new Error('entry linkname must be a non-empty string value when type equals symlink'));
-    return;
-  }
-
-  const entry = new ZipArchiveEntry(data.name);
-  entry.setTime(data.date, this.options.forceLocalTime);
-
-  if (data.store) {
-    entry.setMethod(0);
-  }
-
-  if (data.comment.length > 0) {
-    entry.setComment(data.comment);
-  }
-
-  if (data.type === 'symlink' && typeof data.mode !== 'number') {
-    data.mode = 40960; // 0120000
-  }
-
-  if (typeof data.mode === 'number') {
-    if (data.type === 'symlink') {
-      data.mode |= 40960;
+      if (!isSymlink && data.name.slice(-1) === '/') {
+        isDir = true;
+        data.type = 'directory';
+      } else if (isDir) {
+        data.name += '/';
+      }
     }
 
-    entry.setUnixMode(data.mode);
+    if (isDir || isSymlink) {
+      data.store = true;
+    }
+
+    data.date = util.dateify(data.date);
+
+    return data;
   }
 
-  if (data.type === 'symlink' && typeof data.linkname === 'string') {
-    source = Buffer.from(data.linkname);
+  /**
+   * Appends an entry given an input source (text string, buffer, or stream).
+   *
+   * @param  {(Buffer|Stream|String)} source The input source.
+   * @param  {Object} data
+   * @param  {String} data.name Sets the entry name including internal path.
+   * @param  {String} [data.comment] Sets the entry comment.
+   * @param  {(String|Date)} [data.date=NOW()] Sets the entry date.
+   * @param  {Number} [data.mode=D:0755/F:0644] Sets the entry permissions.
+   * @param  {Boolean} [data.store=options.store] Sets the compression method to STORE.
+   * @param  {String} [data.type=file] Sets the entry type. Defaults to `directory`
+   * if name ends with trailing slash.
+   * @param  {Function} callback
+   * @return this
+   */
+  entry(source, data, callback) {
+    if (typeof callback !== 'function') {
+      callback = this._emitErrorCallback.bind(this);
+    }
+
+    data = this._normalizeFileData(data);
+
+    if (data.type !== 'file' && data.type !== 'directory' && data.type !== 'symlink') {
+      callback(new Error(data.type + ' entries not currently supported'));
+      return;
+    }
+
+    if (typeof data.name !== 'string' || data.name.length === 0) {
+      callback(new Error('entry name must be a non-empty string value'));
+      return;
+    }
+
+    if (data.type === 'symlink' && typeof data.linkname !== 'string') {
+      callback(new Error('entry linkname must be a non-empty string value when type equals symlink'));
+      return;
+    }
+
+    const entry = new ZipArchiveEntry(data.name);
+    entry.setTime(data.date, this.options.forceLocalTime);
+
+    if (data.store) {
+      entry.setMethod(0);
+    }
+
+    if (data.comment.length > 0) {
+      entry.setComment(data.comment);
+    }
+
+    if (data.type === 'symlink' && typeof data.mode !== 'number') {
+      data.mode = 40960; // 0120000
+    }
+
+    if (typeof data.mode === 'number') {
+      if (data.type === 'symlink') {
+        data.mode |= 40960;
+      }
+
+      entry.setUnixMode(data.mode);
+    }
+
+    if (data.type === 'symlink' && typeof data.linkname === 'string') {
+      source = Buffer.from(data.linkname);
+    }
+
+    return super.entry(entry, source, callback);
   }
 
-  return ZipArchiveOutputStream.prototype.entry.call(this, entry, source, callback);
-};
-
-/**
- * Finalizes the instance and prevents further appending to the archive
- * structure (queue will continue til drained).
- *
- * @return void
- */
-ZipStream.prototype.finalize = function() {
-  this.finish();
+  /**
+   * Finalizes the instance and prevents further appending to the archive
+   * structure (queue will continue til drained).
+   *
+   * @return void
+   */
+  finalize() {
+    this.finish();
+  }
 };
 
 /**

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,10 +1,9 @@
-var crypto = require('crypto');
-var fs = require('fs');
-var inherits = require('util').inherits;
+const crypto = require('crypto');
+const fs = require('fs');
+const inherits = require('util').inherits;
 
-var Stream = require('stream').Stream;
-var Readable = require('readable-stream').Readable;
-var Writable = require('readable-stream').Writable;
+const  {Stream } = require('stream');
+const { Readable, Writable } = require('readable-stream').Readable;
 
 function adjustDateByOffset(d, offset) {
   d = (d instanceof Date) ? d : new Date();
@@ -21,9 +20,9 @@ function adjustDateByOffset(d, offset) {
 module.exports.adjustDateByOffset = adjustDateByOffset;
 
 function binaryBuffer(n) {
-  var buffer = Buffer.alloc(n);
+  const buffer = Buffer.alloc(n);
 
-  for (var i = 0; i < n; i++) {
+  for (let i = 0; i < n; i++) {
     buffer.writeUInt8(i&255, i);
   }
 
@@ -35,9 +34,9 @@ module.exports.binaryBuffer = binaryBuffer;
 function BinaryStream(size, options) {
   Readable.call(this, options);
 
-  var buf = Buffer.alloc(size);
+  const buf = Buffer.alloc(size);
 
-  for (var i = 0; i < size; i++) {
+  for (let i = 0; i < size; i++) {
     buf.writeUInt8(i&255, i);
   }
 

--- a/test/pack.js
+++ b/test/pack.js
@@ -1,22 +1,20 @@
 /*global before,describe,it */
-var fs = require('fs');
+const fs = require('fs');
 
-var assert = require('chai').assert;
-var mkdir = require('mkdirp');
+const assert = require('chai').assert;
+const mkdir = require('mkdirp');
 
-var helpers = require('./helpers');
-var binaryBuffer = helpers.binaryBuffer;
-var fileBuffer = helpers.fileBuffer;
+const { binaryBuffer, fileBuffer } = require('./helpers');
 
-var Packer = require('../index.js');
+const Packer = require('../index.js');
 
-var testBuffer = binaryBuffer(1024 * 16);
+const testBuffer = binaryBuffer(1024 * 16);
 
-var testDate = new Date('Jan 03 2013 14:26:38 GMT');
-var testDate2 = new Date('Feb 10 2013 10:24:42 GMT');
+const testDate = new Date('Jan 03 2013 14:26:38 GMT');
+const testDate2 = new Date('Feb 10 2013 10:24:42 GMT');
 
-var testDateOverflow = new Date('Jan 1 2044 00:00:00 GMT');
-var testDateUnderflow = new Date('Dec 30 1979 23:59:58 GMT');
+const testDateOverflow = new Date('Jan 1 2044 00:00:00 GMT');
+const testDateUnderflow = new Date('Dec 30 1979 23:59:58 GMT');
 
 describe('pack', function() {
   before(function() {
@@ -26,9 +24,9 @@ describe('pack', function() {
   describe('#entry', function() {
 
     it('should append Buffer sources', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/buffer.zip');
+      const testStream = fs.createWriteStream('tmp/buffer.zip');
 
       testStream.on('close', function() {
         done();
@@ -41,9 +39,9 @@ describe('pack', function() {
     });
 
     it('should append Stream sources', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/stream.zip');
+      const testStream = fs.createWriteStream('tmp/stream.zip');
 
       testStream.on('close', function() {
         done();
@@ -56,9 +54,9 @@ describe('pack', function() {
     });
 
     it('should append multiple sources', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/multiple.zip');
+      const testStream = fs.createWriteStream('tmp/multiple.zip');
 
       testStream.on('close', function() {
         done();
@@ -82,9 +80,9 @@ describe('pack', function() {
     });
 
     it('should support STORE for Buffer sources', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/buffer-store.zip');
+      const testStream = fs.createWriteStream('tmp/buffer-store.zip');
 
       testStream.on('close', function() {
         done();
@@ -97,9 +95,9 @@ describe('pack', function() {
     });
 
     it('should support STORE for Stream sources', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/stream-store.zip');
+      const testStream = fs.createWriteStream('tmp/stream-store.zip');
 
       testStream.on('close', function() {
         done();
@@ -112,12 +110,12 @@ describe('pack', function() {
     });
 
     it('should support archive and file comments', function(done) {
-      var archive = new Packer({
+      const archive = new Packer({
         comment: 'this is a zip comment',
         forceUTC: true
       });
 
-      var testStream = fs.createWriteStream('tmp/comments.zip');
+      const testStream = fs.createWriteStream('tmp/comments.zip');
 
       testStream.on('close', function() {
         done();
@@ -130,12 +128,12 @@ describe('pack', function() {
     });
 
     it('should STORE files when compression level is zero', function(done) {
-      var archive = new Packer({
+      const archive = new Packer({
         forceUTC: true,
         level: 0
       });
 
-      var testStream = fs.createWriteStream('tmp/store-level0.zip');
+      const testStream = fs.createWriteStream('tmp/store-level0.zip');
 
       testStream.on('close', function() {
         //assert.equal(testStream.digest, '70b50994c971dbb0e457781cf6d23ca82e5ccbc0');
@@ -149,9 +147,9 @@ describe('pack', function() {
     });
 
     it('should properly handle utf8 encoded characters in file names and comments', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/accentedchars-filenames.zip');
+      const testStream = fs.createWriteStream('tmp/accentedchars-filenames.zip');
 
       testStream.on('close', function() {
         done();
@@ -169,9 +167,9 @@ describe('pack', function() {
     });
 
     it('should append zero length sources', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/zerolength.zip');
+      const testStream = fs.createWriteStream('tmp/zerolength.zip');
 
       testStream.on('close', function() {
         done();
@@ -192,9 +190,9 @@ describe('pack', function() {
     });
 
     it('should support setting file mode (permissions)', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/filemode.zip');
+      const testStream = fs.createWriteStream('tmp/filemode.zip');
 
       testStream.on('close', function() {
         done();
@@ -207,9 +205,9 @@ describe('pack', function() {
     });
 
     it('should support creating an empty zip', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/empty.zip');
+      const testStream = fs.createWriteStream('tmp/empty.zip');
 
       testStream.on('close', function() {
         done();
@@ -221,9 +219,9 @@ describe('pack', function() {
     });
 
     it('should support compressing images for Buffer sources', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/buffer-image.zip');
+      const testStream = fs.createWriteStream('tmp/buffer-image.zip');
 
       testStream.on('close', function() {
         done();
@@ -236,9 +234,9 @@ describe('pack', function() {
     });
 
     it('should support compressing images for Stream sources', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/stream-image.zip');
+      const testStream = fs.createWriteStream('tmp/stream-image.zip');
 
       testStream.on('close', function() {
         done();
@@ -251,9 +249,9 @@ describe('pack', function() {
     });
 
     it('should prevent UInt32 under/overflow of dates', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/date-boundaries.zip');
+      const testStream = fs.createWriteStream('tmp/date-boundaries.zip');
 
       testStream.on('close', function() {
         done();
@@ -271,12 +269,12 @@ describe('pack', function() {
     });
 
     it('should handle data that exceeds its internal buffer size', function(done) {
-      var archive = new Packer({
+      const archive = new Packer({
         highWaterMark: 1024 * 4,
         forceUTC: true
       });
 
-      var testStream = fs.createWriteStream('tmp/buffer-overflow.zip');
+      const testStream = fs.createWriteStream('tmp/buffer-overflow.zip');
 
       testStream.on('close', function() {
         done();
@@ -294,9 +292,9 @@ describe('pack', function() {
     });
 
     it('should support directory entries', function(done) {
-      var archive = new Packer();
+      const archive = new Packer();
 
-      var testStream = fs.createWriteStream('tmp/type-directory.zip');
+      const testStream = fs.createWriteStream('tmp/type-directory.zip');
 
       testStream.on('close', function() {
         done();
@@ -310,8 +308,8 @@ describe('pack', function() {
     });
 
     it('should support symlink entries', function(done) {
-        var archive = new Packer();
-        var testStream = fs.createWriteStream('tmp/type-symlink.zip');
+      const archive = new Packer();
+      const testStream = fs.createWriteStream('tmp/type-symlink.zip');
 
         testStream.on('close', function() {
             done();


### PR DESCRIPTION
The following are the ES6 syntax changes done:

1.  Replace var with ES6 let & const 
2. Use object destructing
3. Convert function prototype to class syntax