### PR TITLE
support directory symlinks

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,6 +127,13 @@ ZipStream.prototype.entry = function(source, data, callback) {
     return;
   }
 
+  var isDirectorySymlink = data.type === 'symlink' && data.name.slice(-1) === "/" && data.linkname.slice(-1) === "/"; 
+  
+  if (isDirectorySymlink) {
+    data.name = data.name.slice(0, -1);
+    data.linkname = data.linkname.slice(0, -1);
+  }
+
   var entry = new ZipArchiveEntry(data.name);
   entry.setTime(data.date, this.options.forceLocalTime);
 
@@ -139,7 +146,7 @@ ZipStream.prototype.entry = function(source, data, callback) {
   }
 
   if (data.type === 'symlink' && typeof data.mode !== 'number') {
-    data.mode = 40960; // 0120000
+    data.mode = isDirectorySymlink ? 755 : 40960; // 0120000
   }
 
   if (typeof data.mode === 'number') {

--- a/test/pack.js
+++ b/test/pack.js
@@ -309,9 +309,9 @@ describe('pack', function() {
       archive.finalize();
     });
 
-    it('should support symlink entries', function(done) {
+    it('should support file symlink entries', function(done) {
         var archive = new Packer();
-        var testStream = fs.createWriteStream('tmp/type-symlink.zip');
+        var testStream = fs.createWriteStream('tmp/type-file-symlink.zip');
 
         testStream.on('close', function() {
             done();
@@ -330,6 +330,26 @@ describe('pack', function() {
             });
         });
     });
+
+    it('should support directory symlink entries', function(done) {
+      var archive = new Packer();
+      var testStream = fs.createWriteStream('tmp/type-dir-symlink.zip');
+
+      testStream.on('close', function() {
+          done();
+      });
+
+      archive.pipe(testStream);
+
+      archive.entry(null, { name: 'directory-a/', date: testDate });
+      archive.entry('file-a text', { name: 'directory-a/file-a', date: testDate }, function(err) {
+          if (err) throw err;
+          archive.entry(null, { type: 'symlink', name: 'directory-b/directory-c/', linkname: '../directory-a/', date: testDate }, function(err) {
+              if (err) throw err;
+              archive.finalize();
+          });
+      });
+  });
 
   });
 


### PR DESCRIPTION
Hi. 

I've been trying to create a zip file through `archiver` but was struggling to get the `zip.symlink(linkPath, sourcePath)` to work for directory symlinks. It turns out that `zip-stream` needs to work slightly differently in this situation: the mode needs to include 755. I've switched this behaviour in if the data being supplied indicates that it's a directory symlink via the presence of a `/` suffix on the `name` and the `linkname`. An alternative approach would be to add another boolean (`isDirectorySymlink` or similar), but I didn't want to increase the api surface area.

I've added a test which generates a zip with a directory symlink in it - it seems to work ok for me when I unzip it.