### PR TITLE
chore: remove dependency on readable-stream, use `node:` protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "zip-stream",
-  "version": "6.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zip-stream",
-      "version": "6.0.1",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
         "compress-commons": "^7.0.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "normalize-path": "^3.0.0"
       },
       "devDependencies": {
         "archiver-jsdoc-theme": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   },
   "dependencies": {
     "compress-commons": "^7.0.0",
-    "normalize-path": "^3.0.0",
-    "readable-stream": "^4.0.0"
+    "normalize-path": "^3.0.0"
   },
   "devDependencies": {
     "archiver-jsdoc-theme": "1.1.3",

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,8 +1,6 @@
-import crypto from "crypto";
-import { WriteStream, readFileSync } from "fs";
-import { inherits as inherits$0 } from "util";
-import { Stream } from "stream";
-import { Readable, Writable } from "readable-stream";
+import crypto from "node:crypto";
+import { WriteStream, readFileSync } from "node:fs";
+import { Stream, Readable, Writable } from "node:stream";
 
 export function adjustDateByOffset(d, offset) {
   d = d instanceof Date ? d : new Date();

--- a/test/pack.js
+++ b/test/pack.js
@@ -1,7 +1,7 @@
-import { createReadStream, createWriteStream } from "fs";
+import { createReadStream, createWriteStream } from "node:fs";
 import { assert } from "chai";
 import { mkdirp } from "mkdirp";
-import { Readable } from "readable-stream";
+import { Readable } from "node:stream";
 import { binaryBuffer, fileBuffer } from "./helpers/index.js";
 import Packer from "../index.js";
 


### PR DESCRIPTION
related https://github.com/archiverjs/node-archiver/pull/799

removes legacy dependency of readable-stream and uses `node:protocol`, for better support of edge environments